### PR TITLE
extend consul with dns config

### DIFF
--- a/containerhandler.go
+++ b/containerhandler.go
@@ -61,6 +61,11 @@ func runConsulConfigCopyContainer(client *docker.DockerClient, name string, node
 			HTTP:  8500,
 			HTTPS: -1,
 		},
+		DNS: DNSConfig{
+			AllowStale: true,
+			MaxStale:   "5m",
+			NodeTTL:    "1m",
+		},
 	}
 	if server {
 		log.Debugf("[bootstrap] Node %s is a server, adding bootstrap_expect: %v and server: true configuration options.", node.Name, len(consulServers))

--- a/structs.go
+++ b/structs.go
@@ -23,6 +23,12 @@ type PortConfig struct {
 	HTTPS int
 }
 
+type DNSConfig struct {
+	AllowStale  bool              `json:"allow_stale"`
+	MaxStale    string            `json:"max_stale"`
+	NodeTTL     string            `json:"node_ttl"`
+}
+
 type ConsulConfig struct {
 	BootstrapExpect    int        `json:"bootstrap_expect"`
 	Server             bool       `json:"server"`
@@ -40,4 +46,5 @@ type ConsulConfig struct {
 	CertFile           string     `json:"cert_file,omitempty"`
 	KeyFile            string     `json:"key_file,omitempty"`
 	Ports              PortConfig `json:"ports"`
+	DNS                DNSConfig  `json:"dns_config"`
 }


### PR DESCRIPTION
Adding this DNS config to consul will result that each consul member will cache the hostnames for 1 minute and once that expires they can go to all consul servers. The consul servers cache the hostnames for 5 minutes.

The default behavior is that only the leader can service the DNS requests. This resulted constant leader election, possibly to the heavy messaging within the consul cluster.

**Concern**: I assume once we stop/start the cluster the cache will be cleared, but even if it doesn't it's probably not going to harm as the internal IP's don't change (fixme). 
If we quickly upscale after a downscale (extreme scenario) the new instances might come up with an IP that is already cached.

@lalyos @akanto @martonsereg 
