### PR TITLE
CLOUD-937 Use local DNS recursor in order to avoid sending request to…

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,13 +31,18 @@ var (
 		Value: "",
 		Usage: "Consul log location on local filesystem",
 	}
+	flFallbackDNSRecursors = cli.StringFlag{
+		Name: "fallbackDNSRecursors",
+		Value: "",
+		Usage: "Additional DNS recursors to Consul config as a comma separated list",
+	}
 )
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "munchausen"
 	app.Usage = "Bootstraps a Swarm cluster with Consul"
-	app.Version = "0.5.1"
+	app.Version = "0.5.3"
 	app.Author = "SequenceIQ"
 
 	app.Flags = []cli.Flag{
@@ -57,14 +62,14 @@ func main() {
 			Name:      "bootstrap",
 			ShortName: "b",
 			Usage:     "Bootstraps the cluster. A comma separated list of Docker daemon addresses must be passed as the first argument.",
-			Flags:     []cli.Flag{flConsulServers, flWait, flConsulLogLocation},
+			Flags:     []cli.Flag{flConsulServers, flWait, flConsulLogLocation, flFallbackDNSRecursors},
 			Action:    bootstrap,
 		},
 		{
 			Name:      "add",
 			ShortName: "a",
 			Usage:     "Adds new nodes to a Consul based Swarm cluster. A comma separated list of the new Docker daemons must be passed as the first argument.",
-			Flags:     []cli.Flag{flConsulJoin, flWait, flConsulLogLocation},
+			Flags:     []cli.Flag{flConsulJoin, flWait, flConsulLogLocation, flFallbackDNSRecursors},
 			Action:    add,
 		},
 	}

--- a/structs.go
+++ b/structs.go
@@ -36,7 +36,7 @@ type ConsulConfig struct {
 	DataDir            string     `json:"data_dir"`
 	UiDir              string     `json:"ui_dir"`
 	ClientAddr         string     `json:"client_addr"`
-	DNSRecursor        string     `json:"recursor"`
+	DNSRecursors       []string   `json:"recursors"`
 	DisableUpdateCheck bool       `json:"disable_update_check"`
 	RetryJoin          []string   `json:"retry_join"`
 	EncryptKey         string     `json:"encrypt,omitempty"`

--- a/test/centos7-cluster/Vagrantfile
+++ b/test/centos7-cluster/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, path: "bootstrap.sh"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
     vb.customize ["modifyvm", :id, "--cpus", "1"]
   end
 

--- a/test/centos7-cluster/bootstrap.sh
+++ b/test/centos7-cluster/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${IMAGES:=sequenceiq/consul:v0.5.0-v4 swarm:0.3.0}
+: ${IMAGES:=sequenceiq/consul:v0.5.0-v5 swarm:0.3.0}
 : ${DEBUG:=1}
 
 debug() {

--- a/validation.go
+++ b/validation.go
@@ -64,7 +64,7 @@ func validateNodeUris(nodesArg string) ([]string, error) {
 func validateConsulServerAddresses(consulServers []string) error {
 	for _, serverAddress := range consulServers {
 		if net.ParseIP(serverAddress) == nil {
-			return fmt.Errorf("[bootstrap] Consul server address %s is not a valid IP address", serverAddress)
+			return fmt.Errorf("[validation] Consul server address %s is not a valid IP address", serverAddress)
 		}
 	}
 	return nil


### PR DESCRIPTION
- Use local DNS recursor in order to avoid sending request to 8.8.8.8
- If you want to use the custom recursor then the munchausen shall be started with --dns=8.8.8.8 (which is regular docker flag)
